### PR TITLE
Fix the SBML-exported model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 AbstractFBCModels = "5a4f3dfa-1789-40f8-8221-69268c29937c"
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 COBREXA = "babc4406-5200-4a30-9033-bf5ae714c842"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 ConstraintTrees = "5515826b-29c3-47a5-8849-8513ac836620"
@@ -19,12 +20,13 @@ SBMLFBCModels = "3e8f9d1a-ffc1-486d-82d6-6c7276635980"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+Accessors = "0.1.42"
 ConstraintTrees = "1"
 HiGHS = "1.15.0"
 JSON = "0.21"
 JSONFBCModels = "1"
 RheaReactions = "0.7"
-SBMLFBCModels = "1.1.0"
+SBMLFBCModels = "1.1.1"
 SparseArrays = "1"
 
 [extras]

--- a/scripts/readme.jl
+++ b/scripts/readme.jl
@@ -15,7 +15,7 @@ m = convert(JSONFBCModels.JSONFBCModel, model)
 AbstractFBCModels.save(m, "vibrio_natriegens.json")
 
 m = convert(SBMLFBCModels.SBMLFBCModel, model)
-AbstractFBCModels.save(m, "vibrio_natriegens.sbml")
+AbstractFBCModels.save(m, "vibrio_natriegens.xml")
 
 if nprocs() == 1
     addprocs(7, exeflags = `--project=$(Base.active_project())`)

--- a/scripts/readme.jl
+++ b/scripts/readme.jl
@@ -1,4 +1,5 @@
 # build the readme
+using Accessors
 using VibrioNatriegens
 using AbstractFBCModels
 using JSONFBCModels
@@ -12,10 +13,12 @@ VibrioNatriegens.print_metabolites(model)
 
 # write the model to the main directory in standardized formats
 m = convert(JSONFBCModels.JSONFBCModel, model)
-AbstractFBCModels.save(m, "vibrio_natriegens.json")
+A.save(m, "vibrio_natriegens.json")
 
 m = convert(SBMLFBCModels.SBMLFBCModel, model)
-AbstractFBCModels.save(m, "vibrio_natriegens.xml")
+@reset m.sbml.id = "vibrio_natriegens_1391"
+@reset m.sbml.name = "Vibrio Natriegens 1391 GEM"
+A.save(m, "vibrio_natriegens.xml")
 
 if nprocs() == 1
     addprocs(7, exeflags = `--project=$(Base.active_project())`)


### PR DESCRIPTION
many changes are actually here https://github.com/COBREXA/SBMLFBCModels.jl/pull/6  (again, CI won't work until that's released)

among other:
- GRR is following stylistic choices from SBML (y u no unary and!!!)
- IDs exist
- lower and upper bounds are exported as constant global parameters (somehow SBML loves that)
- some references (GRRs and objectives) are properly SBMLized with the `R_` and `G_` at the beginning

@stelmo please doublecheck the reaction name changes; I hope I didn't regenerate the model with old data or something.